### PR TITLE
M #-: Limit appliances to `appliances` dir

### DIFF
--- a/src/models/appliances.rb
+++ b/src/models/appliances.rb
@@ -13,7 +13,7 @@ class Appliances
 
     def reload
         if File.directory?(@dir)
-            ptrn = @dir + '/**/*.yaml'
+            ptrn = @dir + '/appliances/**/*.yaml'
 #        elsif File.file?(@dir)
 #            ptrn = @dir
         else


### PR DESCRIPTION
Otherwise all *.yaml are considered as appliances
which is broken in community marketplace

```
apps-code/community-apps/appliances/example/context.yaml
apps-code/community-apps/appliances/example/metadata.yaml
apps-code/community-apps/appliances/example/tests.yaml
apps-code/community-apps/appliances/lib/community/ansible/inventory.yaml
apps-code/community-apps/appliances/lib/community/defaults.yaml
```