### PR TITLE
B #-: Fix user-agent issue when version is missing

### DIFF
--- a/src/controllers/appmarket-server.rb
+++ b/src/controllers/appmarket-server.rb
@@ -64,8 +64,7 @@ end
 
 get '/appliance/?' do
     version = request.user_agent.match(/^OpenNebula (\d+\.\d+)/)
-    version = version ? version[1] : appliances.latest_one_version
-
+    version = version && appliances.version?(version[1]) ? version[1] : appliances.latest_one_version
     content_type :json
     apps = appliances.get_all_list(version)
     json :sEcho => 1, :appliances => apps

--- a/src/models/appliances.rb
+++ b/src/models/appliances.rb
@@ -60,6 +60,12 @@ class Appliances
         @cache.keys.empty? ? nil : @cache.keys.max_by {|v| v.split('.').map(&:to_i) }
     end
 
+    def version?(version)
+        return false if version.nil?
+
+        @cache.key?(version)
+    end
+
 end
 
 # vim: ai ts=4 sts=4 et sw=4 ft=ruby


### PR DESCRIPTION
This PR adds a check to avoid returning all appliances when the user-provided User-Agent does not match any existing version. In such cases, it returns only the latest available version.