### PR TITLE
B #-: Fixes appmarketsimple systemd watcher paths

### DIFF
--- a/ansible/appmarket-server/tasks/service.yml
+++ b/ansible/appmarket-server/tasks/service.yml
@@ -1,7 +1,9 @@
 ---
 - name: Find all appliance subdirs
   ansible.builtin.find:
-    paths: "{{ install_path }}/marketplace/appliances/"
+    paths:
+      - /opt/marketplace.git/appliances/default
+      - /opt/marketplace.git/appliances/v6
     file_type: directory
     recurse: false
   register: find_appliance_dirs


### PR DESCRIPTION
With the new marketplace structure, systemd path watcher fails to detect changes in marketplace appliances yaml files (as systemd pathmodified is not recursive) and prevented to restart appmarket simple service for reloading the changes.